### PR TITLE
[PATCH 00/12] tests: refine test implementation

### DIFF
--- a/tests/alsa-firewire
+++ b/tests/alsa-firewire
@@ -9,9 +9,8 @@ import gi
 gi.require_version('Hitaki', '0.0')
 from gi.repository import Hitaki
 
-target_type = Hitaki.SndMotu
+target_type = Hitaki.AlsaFirewire
 props = (
-    # From interface.
     'unit-type',
     'card-id',
     'node-device',
@@ -20,33 +19,18 @@ props = (
     'is-disconnected',
 )
 methods = (
-    'new',
-    # From interfaces.
     'open',
     'lock',
     'unlock',
     'create_source',
-    'read_parameter',
-    'read_byte_meter',
-    'read_float_meter',
 )
 vmethods = (
-    # From interfaces.
     'do_open',
     'do_lock',
     'do_unlock',
     'do_create_source',
-    'do_notified',
-    'do_read_parameter',
-    'do_read_byte_meter',
-    'do_changed',
-    'do_read_float_meter',
 )
-signals = (
-    # From interfaces.
-    'notified',
-    'changed',
-)
+signals = ()
 
 if not test_object(target_type, props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/efw-protocol
+++ b/tests/efw-protocol
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+
+from sys import exit
+from errno import ENXIO
+
+from helper import test_object
+
+import gi
+gi.require_version('Hitaki', '0.0')
+from gi.repository import Hitaki
+
+target_type = Hitaki.EfwProtocol
+props = ()
+methods = (
+    'transmit_request',
+    'receive_response',
+    'transaction',
+)
+vmethods = (
+    'do_transmit_request',
+    'do_get_seqnum',
+    'do_responded',
+)
+signals = (
+    'responded',
+)
+
+if not test_object(target_type, props, methods, vmethods, signals):
+    exit(ENXIO)

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -52,3 +52,11 @@ def test_struct(target_type: object, methods: tuple[str]) -> bool:
             print('Method {0} is not produced.'.format(method))
             return False
     return True
+
+
+def test_functions(target_type: object, functions: tuple[str]) -> bool:
+    for function in functions:
+        if not hasattr(target_type, function):
+            print('Function {0} is not produced.'.format(function))
+            return False
+    return True

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -22,3 +22,12 @@ def test_object(target_type, props, methods, vmethods, signals) ->bool:
             print('Signal {0} is not produced.'.format(signal))
             return False
     return True
+
+
+def test_enums(target_type: object, enumerations: tuple[str]) -> bool:
+    for enumeration in enumerations:
+        if not hasattr(target_type, enumeration):
+            print('Enumeration {0} is not produced for {1}.'.format(
+                enumeration, target_type))
+            return False
+    return True

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -2,21 +2,21 @@ import gi
 gi.require_version('GObject', '2.0')
 from gi.repository import GObject
 
-def test(target, props, methods, vmethods, signals) ->bool:
-    labels = [prop.name for prop in target.props]
+def test(target_type, props, methods, vmethods, signals) ->bool:
+    labels = [prop.name for prop in target_type.props]
     for prop in props:
         if prop not in labels:
             print('Property {0} is not produced.'.format(prop))
             return False
     for method in methods:
-        if not hasattr(target, method):
+        if not hasattr(target_type, method):
             print('Method {0} is not produced.'.format(method))
             return False
     for vmethod in vmethods:
-        if not hasattr(target, method):
+        if not hasattr(target_type, method):
             print('Vmethod {0} is not produced.'.format(vmethod))
             return False
-    labels = GObject.signal_list_names(target)
+    labels = GObject.signal_list_names(target_type)
     for signal in signals:
         if signal not in labels:
             print('Signal {0} is not produced.'.format(signal))

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -2,7 +2,7 @@ import gi
 gi.require_version('GObject', '2.0')
 from gi.repository import GObject
 
-def test(target_type, props, methods, vmethods, signals) ->bool:
+def test_object(target_type, props, methods, vmethods, signals) ->bool:
     labels = [prop.name for prop in target_type.props]
     for prop in props:
         if prop not in labels:

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -31,3 +31,11 @@ def test_enums(target_type: object, enumerations: tuple[str]) -> bool:
                 enumeration, target_type))
             return False
     return True
+
+
+def test_struct(target_type: object, methods: tuple[str]) -> bool:
+    for method in methods:
+        if not hasattr(target_type, method):
+            print('Method {0} is not produced.'.format(method))
+            return False
+    return True

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -1,24 +1,37 @@
-import gi
-gi.require_version('GObject', '2.0')
-from gi.repository import GObject
-
-def test_object(target_type, props, methods, vmethods, signals) ->bool:
-    labels = [prop.name for prop in target_type.props]
-    for prop in props:
-        if prop not in labels:
-            print('Property {0} is not produced.'.format(prop))
-            return False
+def test_object(target_type: object, props: tuple[str], methods: tuple[str],
+                vmethods: tuple[str], signals: tuple[str]) -> bool:
+    # All of available methods are put into the list of attribute.
     for method in methods:
         if not hasattr(target_type, method):
             print('Method {0} is not produced.'.format(method))
             return False
+
+    # The properties, virtual methods, and signals in interface are not put
+    # into the list of attribute in object implementing the interface.
+    prop_labels = []
+    vmethod_labels = []
+    signal_labels = []
+
+    # The  gi.ObjectInfo and gi.InterfaceInfo keeps them. Let's traverse them.
+    for info in target_type.__mro__:
+        if hasattr(info, '__info__'):
+            for prop in info.__info__.get_properties():
+                prop_labels.append(prop.get_name())
+            for vfunc in info.__info__.get_vfuncs():
+                vmethod_labels.append('do_' + vfunc.get_name())
+            for signal in info.__info__.get_signals():
+                signal_labels.append(signal.get_name())
+
+    for prop in props:
+        if prop not in prop_labels:
+            print('Property {0} is not produced.'.format(prop))
+            return False
     for vmethod in vmethods:
-        if not hasattr(target_type, method):
+        if vmethod not in vmethod_labels:
             print('Vmethod {0} is not produced.'.format(vmethod))
             return False
-    labels = GObject.signal_list_names(target_type)
     for signal in signals:
-        if signal not in labels:
+        if signal not in signal_labels:
             print('Signal {0} is not produced.'.format(signal))
             return False
     return True

--- a/tests/hitaki-enum
+++ b/tests/hitaki-enum
@@ -3,7 +3,7 @@
 from sys import exit
 from errno import ENXIO
 
-from helper import test
+from helper import test_object
 
 import gi
 gi.require_version('Hitaki', '0.0')

--- a/tests/hitaki-enum
+++ b/tests/hitaki-enum
@@ -3,7 +3,7 @@
 from sys import exit
 from errno import ENXIO
 
-from helper import test_object
+from helper import test_enums
 
 import gi
 gi.require_version('Hitaki', '0.0')
@@ -58,8 +58,6 @@ types = {
     Hitaki.EfwProtocolError: efw_protocol_error_enumerations,
 }
 
-for obj, types in types.items():
-    for t in types:
-        if not hasattr(obj, t):
-            print('Enumerator {0} is not produced.'.format(t))
+for target_type, enumerations in types.items():
+    if not test_enums(target_type, enumerations):
             exit(ENXIO)

--- a/tests/hitaki-functions
+++ b/tests/hitaki-functions
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+
+from sys import exit
+from errno import ENXIO
+
+import gi
+gi.require_version('Hitaki', '0.0')
+from gi.repository import Hitaki
+
+from helper import test_functions
+
+types = {
+    Hitaki.AlsaFirewireError: (
+        'quark',
+        'to_label',
+    ),
+    Hitaki.EfwProtocolError: (
+        'quark',
+        'to_label',
+    ),
+}
+
+for target_type, functions in types.items():
+    if not test_functions(target_type, functions):
+        exit(ENXIO)

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -12,6 +12,7 @@ tests = [
   'efw-protocol',
   'motu-register-dsp',
   'motu-command-dsp',
+  'tascam-protocol'
 ]
 
 envs = environment()

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -6,6 +6,7 @@ tests = [
   'snd-efw',
   'snd-motu',
   'snd-tascam',
+  'snd-motu-register-dsp-parameter',
 ]
 
 envs = environment()

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -10,6 +10,7 @@ tests = [
   'alsa-firewire',
   'quadlet-notification',
   'efw-protocol',
+  'motu-register-dsp',
 ]
 
 envs = environment()

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -7,6 +7,7 @@ tests = [
   'snd-motu',
   'snd-tascam',
   'snd-motu-register-dsp-parameter',
+  'alsa-firewire',
 ]
 
 envs = environment()

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -9,6 +9,7 @@ tests = [
   'snd-motu-register-dsp-parameter',
   'alsa-firewire',
   'quadlet-notification',
+  'efw-protocol',
 ]
 
 envs = environment()

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -8,6 +8,7 @@ tests = [
   'snd-tascam',
   'snd-motu-register-dsp-parameter',
   'alsa-firewire',
+  'quadlet-notification',
 ]
 
 envs = environment()

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -11,6 +11,7 @@ tests = [
   'quadlet-notification',
   'efw-protocol',
   'motu-register-dsp',
+  'motu-command-dsp',
 ]
 
 envs = environment()

--- a/tests/motu-command-dsp
+++ b/tests/motu-command-dsp
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+
+from sys import exit
+from errno import ENXIO
+
+from helper import test_object
+
+import gi
+gi.require_version('Hitaki', '0.0')
+from gi.repository import Hitaki
+
+target_type = Hitaki.MotuCommandDsp
+props = ()
+methods = (
+    'read_float_meter',
+)
+vmethods = (
+    'do_read_float_meter',
+)
+signals = ()
+
+if not test_object(target_type, props, methods, vmethods, signals):
+    exit(ENXIO)

--- a/tests/motu-register-dsp
+++ b/tests/motu-register-dsp
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+
+from sys import exit
+from errno import ENXIO
+
+from helper import test_object
+
+import gi
+gi.require_version('Hitaki', '0.0')
+from gi.repository import Hitaki
+
+target_type = Hitaki.MotuRegisterDsp
+props = ()
+methods = (
+    'read_parameter',
+    'read_byte_meter',
+)
+vmethods = (
+    'do_read_parameter',
+    'do_read_byte_meter',
+    'do_changed',
+)
+signals = (
+    'changed',
+)
+
+if not test_object(target_type, props, methods, vmethods, signals):
+    exit(ENXIO)

--- a/tests/quadlet-notification
+++ b/tests/quadlet-notification
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+
+from sys import exit
+from errno import ENXIO
+
+from helper import test_object
+
+import gi
+gi.require_version('Hitaki', '0.0')
+from gi.repository import Hitaki
+
+target_type = Hitaki.QuadletNotification
+props = ()
+methods = ()
+vmethods = (
+    'do_notified',
+)
+signals = (
+    'notified',
+)
+
+if not test_object(target_type, props, methods, vmethods, signals):
+    exit(ENXIO)

--- a/tests/snd-dice
+++ b/tests/snd-dice
@@ -11,6 +11,7 @@ from gi.repository import Hitaki
 
 target_type = Hitaki.SndDice
 props = (
+    # From interface.
     'unit-type',
     'card-id',
     'node-device',
@@ -19,13 +20,15 @@ props = (
     'is-disconnected',
 )
 methods = (
+    'new',
+    # From interface.
     'open',
     'lock',
     'unlock',
     'create_source',
-    'new',
 )
 vmethods = (
+    # From interfaces.
     'do_open',
     'do_lock',
     'do_unlock',
@@ -33,7 +36,8 @@ vmethods = (
     'do_notified',
 )
 signals = (
-    #'notified',
+    # From interface.
+    'notified',
 )
 
 if not test_object(target_type, props, methods, vmethods, signals):

--- a/tests/snd-dice
+++ b/tests/snd-dice
@@ -9,7 +9,7 @@ import gi
 gi.require_version('Hitaki', '0.0')
 from gi.repository import Hitaki
 
-target = Hitaki.SndDice()
+target_type = Hitaki.SndDice
 props = (
     'unit-type',
     'card-id',
@@ -36,5 +36,5 @@ signals = (
     #'notified',
 )
 
-if not test(target, props, methods, vmethods, signals):
+if not test(target_type, props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/snd-dice
+++ b/tests/snd-dice
@@ -3,7 +3,7 @@
 from sys import exit
 from errno import ENXIO
 
-from helper import test
+from helper import test_object
 
 import gi
 gi.require_version('Hitaki', '0.0')
@@ -36,5 +36,5 @@ signals = (
     #'notified',
 )
 
-if not test(target_type, props, methods, vmethods, signals):
+if not test_object(target_type, props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/snd-digi00x
+++ b/tests/snd-digi00x
@@ -11,6 +11,7 @@ from gi.repository import Hitaki
 
 target_type = Hitaki.SndDigi00x
 props = (
+    # From interface.
     'unit-type',
     'card-id',
     'node-device',
@@ -19,13 +20,15 @@ props = (
     'is-disconnected',
 )
 methods = (
+    'new',
+    # From interface.
     'open',
     'lock',
     'unlock',
     'create_source',
-    'new',
 )
 vmethods = (
+    # From interfaces.
     'do_open',
     'do_lock',
     'do_unlock',
@@ -33,7 +36,8 @@ vmethods = (
     'do_notified',
 )
 signals = (
-    #'notified',
+    # From interface.
+    'notified',
 )
 
 if not test_object(target_type, props, methods, vmethods, signals):

--- a/tests/snd-digi00x
+++ b/tests/snd-digi00x
@@ -9,7 +9,7 @@ import gi
 gi.require_version('Hitaki', '0.0')
 from gi.repository import Hitaki
 
-target = Hitaki.SndDigi00x()
+target_type = Hitaki.SndDigi00x
 props = (
     'unit-type',
     'card-id',
@@ -36,5 +36,5 @@ signals = (
     #'notified',
 )
 
-if not test(target, props, methods, vmethods, signals):
+if not test(target_type, props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/snd-digi00x
+++ b/tests/snd-digi00x
@@ -3,7 +3,7 @@
 from sys import exit
 from errno import ENXIO
 
-from helper import test
+from helper import test_object
 
 import gi
 gi.require_version('Hitaki', '0.0')
@@ -36,5 +36,5 @@ signals = (
     #'notified',
 )
 
-if not test(target_type, props, methods, vmethods, signals):
+if not test_object(target_type, props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/snd-efw
+++ b/tests/snd-efw
@@ -11,6 +11,7 @@ from gi.repository import Hitaki
 
 target_type = Hitaki.SndEfw
 props = (
+    # From interface.
     'unit-type',
     'card-id',
     'node-device',
@@ -19,16 +20,18 @@ props = (
     'is-disconnected',
 )
 methods = (
+    'new',
+    # From interfaces.
     'open',
     'lock',
     'unlock',
     'create_source',
-    'new',
     'transmit_request',
     'receive_response',
     'transaction',
 )
 vmethods = (
+    # From interfaces.
     'do_open',
     'do_lock',
     'do_unlock',
@@ -38,7 +41,8 @@ vmethods = (
     'do_responded',
 )
 signals = (
-    #'responded',
+    # From interface.
+    'responded',
 )
 
 if not test_object(target_type, props, methods, vmethods, signals):

--- a/tests/snd-efw
+++ b/tests/snd-efw
@@ -3,7 +3,7 @@
 from sys import exit
 from errno import ENXIO
 
-from helper import test
+from helper import test_object
 
 import gi
 gi.require_version('Hitaki', '0.0')
@@ -41,5 +41,5 @@ signals = (
     #'responded',
 )
 
-if not test(target_type, props, methods, vmethods, signals):
+if not test_object(target_type, props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/snd-efw
+++ b/tests/snd-efw
@@ -9,7 +9,7 @@ import gi
 gi.require_version('Hitaki', '0.0')
 from gi.repository import Hitaki
 
-target = Hitaki.SndEfw()
+target_type = Hitaki.SndEfw
 props = (
     'unit-type',
     'card-id',
@@ -41,5 +41,5 @@ signals = (
     #'responded',
 )
 
-if not test(target, props, methods, vmethods, signals):
+if not test(target_type, props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/snd-motu
+++ b/tests/snd-motu
@@ -3,7 +3,7 @@
 from sys import exit
 from errno import ENXIO
 
-from helper import test
+from helper import test_object
 
 import gi
 gi.require_version('Hitaki', '0.0')
@@ -44,5 +44,5 @@ signals = (
     #'changed',
 )
 
-if not test(target_type, props, methods, vmethods, signals):
+if not test_object(target_type, props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/snd-motu
+++ b/tests/snd-motu
@@ -9,7 +9,7 @@ import gi
 gi.require_version('Hitaki', '0.0')
 from gi.repository import Hitaki
 
-target = Hitaki.SndMotu()
+target_type = Hitaki.SndMotu
 props = (
     'unit-type',
     'card-id',
@@ -44,5 +44,5 @@ signals = (
     #'changed',
 )
 
-if not test(target, props, methods, vmethods, signals):
+if not test(target_type, props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/snd-motu-register-dsp-parameter
+++ b/tests/snd-motu-register-dsp-parameter
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+
+from sys import exit
+from errno import ENXIO
+
+from helper import test_struct
+
+import gi
+gi.require_version('Hitaki', '0.0')
+from gi.repository import Hitaki
+
+target_type = Hitaki.SndMotuRegisterDspParameter
+methods = (
+    'new',
+    'get_mixer_source_gain',
+    'get_mixer_source_pan',
+    'get_mixer_source_flag',
+    'get_mixer_source_paired_balance',
+    'get_mixer_source_paired_width',
+    'get_mixer_output_paired_volume',
+    'get_mixer_output_paired_flag',
+    'get_main_output_paired_volume',
+    'get_headphone_output_paired_volume',
+    'get_headphone_output_paired_assignment',
+    'get_line_input_boost_flag',
+    'get_line_input_nominal_level_flag',
+    'get_input_gain_and_invert',
+    'get_input_flag',
+)
+
+if not test_struct(target_type, methods):
+    exit(ENXIO)

--- a/tests/snd-tascam
+++ b/tests/snd-tascam
@@ -11,6 +11,7 @@ from gi.repository import Hitaki
 
 target_type = Hitaki.SndTascam
 props = (
+    # From interface.
     'unit-type',
     'card-id',
     'node-device',
@@ -19,14 +20,16 @@ props = (
     'is-disconnected',
 )
 methods = (
+    'new',
+    # From interfaces.
     'open',
     'lock',
     'unlock',
     'create_source',
-    'new',
     'read_state',
 )
 vmethods = (
+    # From interfaces.
     'do_open',
     'do_lock',
     'do_unlock',
@@ -35,7 +38,8 @@ vmethods = (
     'do_changed',
 )
 signals = (
-    #'changed',
+    # From interface.
+    'changed',
 )
 
 if not test_object(target_type, props, methods, vmethods, signals):

--- a/tests/snd-tascam
+++ b/tests/snd-tascam
@@ -3,7 +3,7 @@
 from sys import exit
 from errno import ENXIO
 
-from helper import test
+from helper import test_object
 
 import gi
 gi.require_version('Hitaki', '0.0')
@@ -38,5 +38,5 @@ signals = (
     #'changed',
 )
 
-if not test(target_type, props, methods, vmethods, signals):
+if not test_object(target_type, props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/snd-tascam
+++ b/tests/snd-tascam
@@ -9,7 +9,7 @@ import gi
 gi.require_version('Hitaki', '0.0')
 from gi.repository import Hitaki
 
-target = Hitaki.SndTascam()
+target_type = Hitaki.SndTascam
 props = (
     'unit-type',
     'card-id',
@@ -38,5 +38,5 @@ signals = (
     #'changed',
 )
 
-if not test(target, props, methods, vmethods, signals):
+if not test(target_type, props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/snd-unit
+++ b/tests/snd-unit
@@ -11,6 +11,7 @@ from gi.repository import Hitaki
 
 target_type = Hitaki.SndUnit
 props = (
+    # From interface.
     'unit-type',
     'card-id',
     'node-device',
@@ -19,13 +20,15 @@ props = (
     'is-disconnected',
 )
 methods = (
+    'new',
+    # From interface.
     'open',
     'lock',
     'unlock',
     'create_source',
-    'new',
 )
 vmethods = (
+    # From interface.
     'do_open',
     'do_lock',
     'do_unlock',

--- a/tests/snd-unit
+++ b/tests/snd-unit
@@ -3,7 +3,7 @@
 from sys import exit
 from errno import ENXIO
 
-from helper import test
+from helper import test_object
 
 import gi
 gi.require_version('Hitaki', '0.0')
@@ -33,5 +33,5 @@ vmethods = (
 )
 signals = ()
 
-if not test(target_type, props, methods, vmethods, signals):
+if not test_object(target_type, props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/snd-unit
+++ b/tests/snd-unit
@@ -9,7 +9,7 @@ import gi
 gi.require_version('Hitaki', '0.0')
 from gi.repository import Hitaki
 
-target = Hitaki.SndUnit()
+target_type = Hitaki.SndUnit
 props = (
     'unit-type',
     'card-id',
@@ -33,5 +33,5 @@ vmethods = (
 )
 signals = ()
 
-if not test(target, props, methods, vmethods, signals):
+if not test(target_type, props, methods, vmethods, signals):
     exit(ENXIO)

--- a/tests/tascam-protocol
+++ b/tests/tascam-protocol
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+from sys import exit
+from errno import ENXIO
+
+from helper import test_object
+
+import gi
+gi.require_version('Hitaki', '0.0')
+from gi.repository import Hitaki
+
+target_type = Hitaki.TascamProtocol
+props = ()
+methods = (
+    'read_state',
+)
+vmethods = (
+    'do_read_state',
+    'do_changed',
+)
+signals = (
+    'changed',
+)
+
+if not test_object(target_type, props, methods, vmethods, signals):
+    exit(ENXIO)


### PR DESCRIPTION
Current implementation of test just supports GObject-derived object,
enumerations, and flags. It's not possible to test the other types of
glib/gobject elements such as boxed structure.

This patchset refines test implementation. Some helper functions for
boxed structure and namespace/object functions are added. The existent
helper function is renamed as 'test_object' and rewritten to walk through
Python MRO hierarchy to check properties, virtual methods, and signals,
defined by both GObject-derived objects and interfaces.

I note that the tests are not done to execute actual symbols. They are just
to check they are available or not via interface described in metadata of
GObject Introspection.


```
Takashi Sakamoto (12):
  tests: test object type instead of its instance
  tests: rename helper function to test object interface
  tests: add helper function to test enumerations and flags
  tests: add test script for Hitaki.SndMotuRegisterDspParameter boxed structure
  tests: refine helper function to test object
  tests: add test script for Hitaki.AlsaFirewire interface
  tests: add test script for Hitaki.QuadletNotification interface
  tests: add test script for Hitaki.EfwProtocol interface
  tests: add tests script for Hitaki.MotuRegisterDsp interface
  tests: add test script for Hitaki.MotuCommandDsp interface
  tests: add test script for Hitaki.TascamProtocol interface
  tests: add test script for namespace and object functions

 tests/alsa-firewire                   | 36 +++++++++++++++
 tests/efw-protocol                    | 29 ++++++++++++
 tests/helper.py                       | 64 +++++++++++++++++++++------
 tests/hitaki-enum                     |  8 ++--
 tests/hitaki-functions                | 25 +++++++++++
 tests/meson.build                     |  7 +++
 tests/motu-command-dsp                | 23 ++++++++++
 tests/motu-register-dsp               | 28 ++++++++++++
 tests/quadlet-notification            | 23 ++++++++++
 tests/snd-dice                        | 14 +++---
 tests/snd-digi00x                     | 14 +++---
 tests/snd-efw                         | 14 +++---
 tests/snd-motu                        | 16 ++++---
 tests/snd-motu-register-dsp-parameter | 32 ++++++++++++++
 tests/snd-tascam                      | 14 +++---
 tests/snd-unit                        | 11 +++--
 tests/tascam-protocol                 | 26 +++++++++++
 17 files changed, 336 insertions(+), 48 deletions(-)
 create mode 100644 tests/alsa-firewire
 create mode 100644 tests/efw-protocol
 create mode 100644 tests/hitaki-functions
 create mode 100644 tests/motu-command-dsp
 create mode 100644 tests/motu-register-dsp
 create mode 100644 tests/quadlet-notification
 create mode 100644 tests/snd-motu-register-dsp-parameter
 create mode 100644 tests/tascam-protocol
```